### PR TITLE
added f_timer decorator

### DIFF
--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -9,7 +9,7 @@ from typing import Generator, List, Optional, Tuple
 
 from .ansi import isatty, sformat
 from .prettier import PrettyFormat, env_true
-from .timer import Timer
+from .timer import Timer, f_timer
 
 __all__ = 'Debug', 'debug'
 CWD = Path('.').resolve()
@@ -130,6 +130,9 @@ class Debug:
 
     def timer(self, name=None, *, verbose=True, file=None, dp=3) -> Timer:
         return Timer(name=name, verbose=verbose, file=file, dp=dp)
+
+    def f_timer(self, name=None, *, verbose=True, file=None, dp=3) -> Timer:
+        return f_timer(name=name, verbose=verbose, file=file, dp=dp)
 
     def _process(self, args, kwargs, func_regex) -> DebugOutput:
         curframe = inspect.currentframe()

--- a/devtools/timer.py
+++ b/devtools/timer.py
@@ -90,3 +90,25 @@ class Timer:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.capture()
+
+
+def f_timer(*args, **kwargs):
+    '''
+    call timer each time a function or method is called
+    '''
+
+    def decorator(func):
+
+        def wrapper(*f_args, **f_kwargs):
+
+            t = Timer(*args, **kwargs)
+
+            with t:
+
+                result = func(*f_args, **f_kwargs)
+
+            return result
+
+        return wrapper
+
+    return decorator

--- a/docs/examples/more_debug.py
+++ b/docs/examples/more_debug.py
@@ -16,6 +16,11 @@ t2 = debug.timer('sort values').start()
 sorted(values)
 t2.capture()
 
+# timer can also be added to a function or class method as a decorator
+@debug.f_timer('shuffle_values_fcn')
+def shuffle_values_fcn(values):
+    return random.shuffle(values)
+
 # if used repeatedly a summary is available
 t3 = debug.timer()
 for i in [1e4, 1e6, 1e7]:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ The debug namespace includes a number of other useful functions:
 
 * ``debug.format()`` same as calling ``debug()`` but returns a ``DebugOutput`` rather than printing the output
 * ``debug.timer()`` returns an instance of *devtool's* ``Timer`` class suitable for timing code execution
+* ``debug.f_timer()`` returns an instance of *devtool's* ``Timer`` class as a decorator
 * ``debug.breakpoint()`` introduces a breakpoint using ``pdb``
 
 

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -64,3 +64,12 @@ def test_unfinished_summary():
 def test_summary_not_started():
     with pytest.raises(RuntimeError):
         Timer().summary()
+
+
+def test_f_timer():
+    f = io.StringIO()
+    @debug.f_timer('f_timer_test', file=f)
+    def f_timer_fcn(i):
+        return [sleep(1) for s in range(i)]
+    f_timer_fcn(1)
+    assert re.match(r'f_timer_test: [0-9]*\.?[0-9]*s elapsed', f.getvalue())


### PR DESCRIPTION
I added f_timer, a decorator function that wraps a function or method call with an instance of your Timer class for easy use of Timer in development.  I also added a unit test and updated your documentation for f_timer.  

FYI, I noticed that the unit tests would sporadically fail due to slight variances in the timing (inside a Docker container).  Consider updating your regex to look more like f_timer_test.
