### PR TITLE
Defer importing `devtools` in `sitecustomize.py`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ modify ``/usr/lib/python3.6/sitecustomize.py`` making ``debug`` available in any
            from devtools import debug
            return debug
 
-    __builtins__['debug'] = lazy_debug
+   __builtins__['debug'] = lazy_debug()
 
 .. |BuildStatus| image:: https://travis-ci.org/samuelcolvin/python-devtools.svg?branch=master
    :target: https://travis-ci.org/samuelcolvin/python-devtools

--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,14 @@ modify ``/usr/lib/python3.6/sitecustomize.py`` making ``debug`` available in any
 .. code:: python
 
    # add devtools debug to builtins
-   try:
-       from devtools import debug
-   except ImportError:
-       pass
-   else:
-       __builtins__['debug'] = debug
+   class lazy_debug:
+
+       @property
+       def __call__(self):
+           from devtools import debug
+           return debug
+
+    __builtins__['debug'] = lazy_debug
 
 .. |BuildStatus| image:: https://travis-ci.org/samuelcolvin/python-devtools.svg?branch=master
    :target: https://travis-ci.org/samuelcolvin/python-devtools

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,10 @@ modify ``/usr/lib/python3.6/sitecustomize.py`` making ``debug`` available in any
            from devtools import debug
            return debug
 
+       def __getattr__(self, key):
+           from devtools import debug
+           return getattr(debug, key)
+
    __builtins__['debug'] = lazy_debug()
 
 .. |BuildStatus| image:: https://travis-ci.org/samuelcolvin/python-devtools.svg?branch=master

--- a/docs/examples/sitecustomize.py
+++ b/docs/examples/sitecustomize.py
@@ -1,8 +1,14 @@
 ...
 
-try:
-    from devtools import debug
-except ImportError:
-    pass
-else:
-    __builtins__['debug'] = debug
+class lazy_debug:
+
+    @property
+    def __call__(self):
+        from devtools import debug
+        return debug
+
+    def __getattr__(self, key):
+        from devtools import debug
+        return getattr(debug, key)
+
+__builtins__['debug'] = lazy_debug()


### PR DESCRIPTION
It's convenient to be able to use `debug()` as if it were a builtin function, but importing `devtools` directly in `sitecustomize.py` is a pretty significant performance hit for every invocation of python that doesn't use `debug()`.  Specifically, this import takes 100-200 ms, which is a noticeable delay for interactive sessions and short-running scripts:

    $ python -X importtime -c 'import devtools'

While it would probably be possible to make `devtools` faster to import, the best solution is simply to avoid importing `devtools` unless it will be used.  It took me a while to figure out how to do this, but in the end the code is pretty clear and succinct, and I think it will be useful to others:

```python
# sitecustomize.py
class lazy_debug:
    @property
    def __call__(self):
        from devtools import debug
        return debug

__builtins__['debug'] = lazy_debug()
```

This PR updates the `README` file to include the above snippet.