### PR TITLE
improve the way statement ranges are caculcated

### DIFF
--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -295,7 +295,7 @@ class Debug:
         return func_ast, code_lines
 
     @staticmethod  # noqa: C901
-    def _statement_range(call_frame: FrameType, func_name: str) -> Tuple[int, int]:
+    def _statement_range(call_frame: FrameType, func_name: str) -> Tuple[int, int]:  # noqa: C901
         """
         Try to find the start and end of a frame statement.
         """

--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -319,7 +319,7 @@ class Debug:
         if first_line is None:
             raise IntrospectionError('error parsing code, unable to find "{}" function statement'.format(func_name))
 
-        for instr in instructions:
+        for instr in instructions:  # pragma: no branch
             if instr.offset == call_frame.f_lasti:
                 break
 

--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -1,10 +1,12 @@
 import ast
+import dis
 import inspect
 import os
 import pdb
-import re
+import sys
 from pathlib import Path
 from textwrap import dedent, indent
+from types import FrameType
 from typing import Generator, List, Optional, Tuple
 
 from .ansi import isatty, sformat
@@ -21,6 +23,10 @@ pformat = PrettyFormat(
     width=int(os.getenv('PY_DEVTOOLS_WIDTH', 120)),
     yield_from_generators=env_true('PY_DEVTOOLS_YIELD_FROM_GEN', True),
 )
+
+
+class IntrospectionError(ValueError):
+    pass
 
 
 class DebugArgument:
@@ -134,13 +140,13 @@ class Debug:
             return value
 
     def __call__(self, *args, file_=None, flush_=True, **kwargs) -> None:
-        d_out = self._process(args, kwargs, r'debug *\(')
+        d_out = self._process(args, kwargs, 'debug')
         highlight = isatty(file_) if self._highlight is None else self._highlight
         s = d_out.str(highlight)
         print(s, file=file_, flush=flush_)
 
     def format(self, *args, **kwargs) -> DebugOutput:
-        return self._process(args, kwargs, r'debug.format *\(')
+        return self._process(args, kwargs, 'format')
 
     def breakpoint(self):
         pdb.Pdb(skip=['devtools.*']).set_trace()
@@ -148,24 +154,25 @@ class Debug:
     def timer(self, name=None, *, verbose=True, file=None, dp=3) -> Timer:
         return Timer(name=name, verbose=verbose, file=file, dp=dp)
 
-    def _process(self, args, kwargs, func_regex) -> DebugOutput:
-        curframe = inspect.currentframe()
+    def _process(self, args, kwargs, func_name: str) -> DebugOutput:
+        """
+        BEWARE: this must be called from a function exactly 2 levels below the top of the stack.
+        """
+        # HELP: any errors other than ValueError from _getframe? If so please submit an issue
         try:
-            frames = inspect.getouterframes(curframe, context=self._frame_context_length)
-        except IndexError:
-            # NOTICE: we should really catch all conceivable errors here, if you find one please report.
-            # IndexError happens in odd situations such as code called from within jinja templates
+            call_frame: FrameType = sys._getframe(2)
+        except ValueError:
+            # "If [ValueError] is deeper than the call stack, ValueError is raised"
             return self.output_class(
                 filename='<unknown>',
                 lineno=0,
                 frame='',
                 arguments=list(self._args_inspection_failed(args, kwargs)),
-                warning=self._show_warnings and 'error parsing code, IndexError',
+                warning=self._show_warnings and 'error parsing code, call stack too shallow',
             )
-        # BEWARE: this must be called by a method which in turn is called "directly" for the frame to be correct
-        call_frame = frames[2]
 
-        filename = call_frame.filename
+        filename = call_frame.f_code.co_filename
+        function = call_frame.f_code.co_name
         if filename.startswith('/'):
             # make the path relative
             try:
@@ -174,22 +181,29 @@ class Debug:
                 # happens if filename path is not within CWD
                 pass
 
-        if call_frame.code_context:
-            func_ast, code_lines, lineno, warning = self._parse_code(call_frame, func_regex, filename)
-            if func_ast:
-                arguments = list(self._process_args(func_ast, code_lines, args, kwargs))
-            else:
-                # parsing failed
-                arguments = list(self._args_inspection_failed(args, kwargs))
-        else:
-            lineno = call_frame.lineno
+        lineno = call_frame.f_lineno
+        warning = None
+
+        try:
+            file_lines, _ = inspect.findsource(call_frame)
+        except OSError:
             warning = 'no code context for debug call, code inspection impossible'
             arguments = list(self._args_inspection_failed(args, kwargs))
+        else:
+            try:
+                first_line, last_line = self._statement_range(call_frame, func_name)
+                func_ast, code_lines = self._parse_code(filename, file_lines, first_line, last_line)
+            except IntrospectionError as e:
+                # parsing failed
+                warning = e.args[0]
+                arguments = list(self._args_inspection_failed(args, kwargs))
+            else:
+                arguments = list(self._process_args(func_ast, code_lines, args, kwargs))
 
         return self.output_class(
             filename=filename,
             lineno=lineno,
-            frame=call_frame.function,
+            frame=function,
             arguments=arguments,
             warning=self._show_warnings and warning,
         )
@@ -238,34 +252,29 @@ class Debug:
             yield self.output_class.arg_class(value, name=name, variable=kw_arg_names.get(name))
 
     def _parse_code(
-        self, call_frame, func_regex, filename
-    ) -> Tuple[Optional[ast.AST], Optional[List[str]], int, Optional[str]]:
-        call_lines = []
-        for line in range(call_frame.index, -1, -1):
-            try:
-                new_line = call_frame.code_context[line]
-            except IndexError:  # pragma: no cover
-                return None, None, line, 'error parsing code. line not found'
-            call_lines.append(new_line)
-            if re.search(func_regex, new_line):
-                break
-        call_lines.reverse()
-        lineno = call_frame.lineno - len(call_lines) + 1
+        self, filename: str, file_lines: List[str], first_line: int, last_line: int
+    ) -> Tuple[ast.AST, List[str]]:
+        """
+        All we're trying to do here is build an AST of the function call statement. However numerous ugly interfaces,
+        lack on introspection support and changes between python versions make this extremely hard.
+        """
 
-        code = dedent(''.join(call_lines))
+        def get_code(_last_line: int) -> str:
+            lines = file_lines[first_line - 1 : _last_line]
+            return dedent(''.join(ln for ln in lines if ln.strip('\n ') and not ln.lstrip(' ').startswith('#')))
+
+        code = get_code(last_line)
         func_ast = None
-        tail_index = call_frame.index
         try:
             func_ast = self._wrap_parse(code, filename)
         except (SyntaxError, AttributeError) as e1:
-            # if the trailing bracket(s) of the function is/are on a new line eg.
+            # if the trailing bracket(s) of the function is/are on a new line e.g.:
             # debug(
             #     foo, bar,
             # )
             # inspect ignores it when setting index and we have to add it back
-            for extra in range(2, 6):
-                extra_lines = call_frame.code_context[tail_index + 1 : tail_index + extra]
-                code = dedent(''.join(call_lines + extra_lines))
+            for extra in range(1, 6):
+                code = get_code(last_line + extra)
                 try:
                     func_ast = self._wrap_parse(code, filename)
                 except (SyntaxError, AttributeError):
@@ -274,16 +283,64 @@ class Debug:
                     break
 
             if not func_ast:
-                return None, None, lineno, 'error parsing code, {0.__class__.__name__}: {0}'.format(e1)
+                raise IntrospectionError('error parsing code, {0.__class__.__name__}: {0}'.format(e1))
 
         if not isinstance(func_ast, ast.Call):
-            return None, None, lineno, 'error parsing code, found {} not Call'.format(func_ast.__class__)
+            raise IntrospectionError('error parsing code, found {0.__class__} not Call'.format(func_ast))
 
         code_lines = [line for line in code.split('\n') if line]
         # this removes the trailing bracket from the lines of code meaning it doesn't appear in the
         # representation of the last argument
         code_lines[-1] = code_lines[-1][:-1]
-        return func_ast, code_lines, lineno, None
+        return func_ast, code_lines
+
+    @staticmethod  # noqa: C901
+    def _statement_range(call_frame: FrameType, func_name: str) -> Tuple[int, int]:
+        """
+        Try to find the start and end of a frame statement.
+        """
+        # dis.disassemble(call_frame.f_code, call_frame.f_lasti)
+        # pprint([i for i in dis.get_instructions(call_frame.f_code)])
+
+        instructions = iter(dis.get_instructions(call_frame.f_code))
+        first_line = None
+        last_line = None
+
+        for instr in instructions:
+            if instr.starts_line:
+                if instr.opname in {'LOAD_GLOBAL', 'LOAD_NAME'} and instr.argval == func_name:
+                    first_line = instr.starts_line
+                    break
+                elif instr.opname == 'LOAD_GLOBAL' and instr.argval == 'debug':
+                    if next(instructions).argval == func_name:
+                        first_line = instr.starts_line
+                        break
+
+        if first_line is None:
+            raise IntrospectionError('error parsing code, unable to find "{}" function statement'.format(func_name))
+
+        for instr in instructions:
+            if instr.offset == call_frame.f_lasti:
+                break
+
+        for instr in instructions:
+            if instr.starts_line:
+                last_line = instr.starts_line - 1
+                break
+
+        if last_line is None:
+            if sys.version_info >= (3, 8):
+                # absolutely no reliable way of getting the last line of the statement, complete hack is to
+                # get the last line of the last statement of the whole code block and go from there
+                # this assumes (perhaps wrongly?) that the reason we couldn't find last_line is that the statement
+                # in question was the last of the block
+                last_line = max(i.starts_line for i in dis.get_instructions(call_frame.f_code) if i.starts_line)
+            else:
+                # in older version of python f_lineno is the end of the statement, not the beginning
+                # so this is a reasonable guess
+                last_line = call_frame.f_lineno
+
+        return first_line, last_line
 
     @staticmethod
     def _wrap_parse(code, filename):

--- a/tests/test_expr_render.py
+++ b/tests/test_expr_render.py
@@ -32,7 +32,6 @@ def test_subscription():
     ) == s
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 8), reason='TODO fix for python 3.8')
 def test_exotic_types():
     aa = [1, 2, 3]
     v = debug.format(
@@ -139,7 +138,6 @@ def test_kwargs():
     ) == s
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 8), reason='TODO fix for python 3.8')
 @pytest.mark.skipif(sys.version_info < (3, 6), reason='kwarg order is not guaranteed for 3.5')
 def test_kwargs_multiline():
     v = debug.format(
@@ -169,8 +167,7 @@ def test_multiple_trailing_lines():
     ) == s
 
 
-def test_syntax_warning():
-    # exceed the 4 extra lines which are normally checked
+def test_very_nested():
     v = debug.format(
         abs(
             abs(
@@ -184,8 +181,10 @@ def test_syntax_warning():
     )
     # check only the original code is included in the warning
     s = re.sub(r':\d{2,}', ':<line no>', str(v))
-    assert s.startswith('tests/test_expr_render.py:<line no> test_syntax_warning (error parsing code, '
-                        'SyntaxError: unexpected EOF')
+    assert s == (
+        'tests/test_expr_render.py:<line no> test_very_nested\n'
+        '    abs( abs( abs( abs( -1 ) ) ) ): 1 (int)'
+    )
 
 
 def test_no_syntax_warning():

--- a/tests/test_expr_render.py
+++ b/tests/test_expr_render.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import re
 import sys
@@ -266,3 +267,12 @@ def test_other_debug_arg():
         'tests/test_expr_render.py:<line no> test_other_debug_arg\n'
         '    [1, 2] (list) len=2'
     )
+
+
+def test_wrong_ast_type(mocker):
+    mocked_ast_parse = mocker.patch('ast.parse')
+
+    code = 'async def wrapper():\n x = "foobar"'
+    mocked_ast_parse.return_value = ast.parse(code, filename='testing.py').body[0].body[0].value
+    v = debug.format('x')
+    assert "(error parsing code, found <class 'unittest.mock.MagicMock'> not Call)" in v.str()

--- a/tests/test_expr_render.py
+++ b/tests/test_expr_render.py
@@ -187,6 +187,29 @@ def test_very_nested():
     )
 
 
+def test_very_nested_last_statement():
+    def func():
+        return debug.format(
+            abs(
+                abs(
+                    abs(
+                        abs(
+                            -1
+                        )
+                    )
+                )
+            )
+        )
+
+    v = func()
+    # check only the original code is included in the warning
+    s = re.sub(r':\d{2,}', ':<line no>', str(v))
+    assert s == (
+        'tests/test_expr_render.py:<line no> func\n'
+        '    abs( abs( abs( abs( -1 ) ) ) ): 1 (int)'
+    )
+
+
 def test_no_syntax_warning():
     # exceed the 4 extra lines which are normally checked
     debug_ = Debug(warnings=False)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,7 @@ def test_format():
     b = "hello this is a test"
     v = debug.format(a, b)
     s = re.sub(r':\d{2,}', ':<line no>', str(v))
-    print(repr(s))
+    print(s)
     assert s == (
         "tests/test_main.py:<line no> test_format\n"
         "    a: b'i might bite' (bytes) len=12\n"
@@ -88,7 +88,6 @@ def test_small_call_frame():
     )
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 8), reason='TODO fix for python 3.8')
 def test_small_call_frame_warning():
     debug_ = Debug(frame_context_length=2)
     v = debug_.format(
@@ -98,11 +97,11 @@ def test_small_call_frame_warning():
     )
     print('\n---\n{}\n---'.format(v))
     assert re.sub(r':\d{2,}', ':<line no>', str(v)) == (
-        "tests/test_main.py:<line no> test_small_call_frame_warning "
-        "(error parsing code, found <class '_ast.Tuple'> not Call)\n"
-        "    1 (int)\n"
-        "    2 (int)\n"
-        "    3 (int)"
+        'tests/test_main.py:<line no> test_small_call_frame_warning '
+        '(error parsing code, unable to find "format" function statement)\n'
+        '    1 (int)\n'
+        '    2 (int)\n'
+        '    3 (int)'
     )
 
 
@@ -209,8 +208,8 @@ def test_colours():
 
 
 def test_colours_warnings(mocker):
-    mocked_getouterframes = mocker.patch('inspect.getouterframes')
-    mocked_getouterframes.side_effect = IndexError()
+    mocked_getouterframes = mocker.patch('sys._getframe')
+    mocked_getouterframes.side_effect = ValueError()
     v = debug.format('x')
     s = re.sub(r':\d{2,}', ':<line no>', v.str(True))
     assert s.startswith('\x1b[35m<unknown>'), repr(s)
@@ -219,10 +218,11 @@ def test_colours_warnings(mocker):
 
 
 def test_inspect_error(mocker):
-    mocked_getouterframes = mocker.patch('inspect.getouterframes')
-    mocked_getouterframes.side_effect = IndexError()
+    mocked_getouterframes = mocker.patch('sys._getframe')
+    mocked_getouterframes.side_effect = ValueError()
     v = debug.format('x')
-    assert str(v) == "<unknown>:0  (error parsing code, IndexError)\n    'x' (str) len=1"
+    print(repr(str(v)))
+    assert str(v) == "<unknown>:0  (error parsing code, call stack too shallow)\n    'x' (str) len=1"
 
 
 def test_breakpoint(mocker):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -208,8 +208,8 @@ def test_colours():
 
 
 def test_colours_warnings(mocker):
-    mocked_getouterframes = mocker.patch('sys._getframe')
-    mocked_getouterframes.side_effect = ValueError()
+    mocked_getframe = mocker.patch('sys._getframe')
+    mocked_getframe.side_effect = ValueError()
     v = debug.format('x')
     s = re.sub(r':\d{2,}', ':<line no>', v.str(True))
     assert s.startswith('\x1b[35m<unknown>'), repr(s)
@@ -218,8 +218,8 @@ def test_colours_warnings(mocker):
 
 
 def test_inspect_error(mocker):
-    mocked_getouterframes = mocker.patch('sys._getframe')
-    mocked_getouterframes.side_effect = ValueError()
+    mocked_getframe = mocker.patch('sys._getframe')
+    mocked_getframe.side_effect = ValueError()
     v = debug.format('x')
     print(repr(str(v)))
     assert str(v) == "<unknown>:0  (error parsing code, call stack too shallow)\n    'x' (str) len=1"


### PR DESCRIPTION
fixes #56

This should:
* allow multiline `debug` statements to work on python 3.8
* speed up introspection by going straight to `sys._getframe()` and `dis` rather than using `inspect` and regexes (this might not have a significant effect since I think pygments responsible for most of the slowness)