### PR TITLE
Format mappingproxy as dict

### DIFF
--- a/devtools/prettier.py
+++ b/devtools/prettier.py
@@ -2,6 +2,7 @@ import io
 import os
 from collections import OrderedDict
 from collections.abc import Generator
+from types import MappingProxyType
 
 from .utils import env_true, isatty
 
@@ -56,7 +57,7 @@ class PrettyFormat:
         self._simple_cutoff = simple_cutoff
         self._width = width
         self._type_lookup = [
-            (dict, self._format_dict),
+            ((dict, MappingProxyType), self._format_dict),
             ((str, bytes), self._format_str_bytes),
             (tuple, self._format_tuples),
             ((list, set, frozenset), self._format_list_like),

--- a/tests/test_prettier.py
+++ b/tests/test_prettier.py
@@ -37,7 +37,9 @@ def test_dict():
 
 
 def test_mappingproxy():
-    class C: pass
+    class C:
+        pass
+
     v = pformat(C.__dict__)
     print(v)
     assert v == (

--- a/tests/test_prettier.py
+++ b/tests/test_prettier.py
@@ -37,15 +37,16 @@ def test_dict():
 
 
 def test_mappingproxy():
+    class C: pass
     v = pformat(C.__dict__)
     print(v)
     assert v == (
-        "<mappingproxy({{\n"
+        "<mappingproxy({\n"
         "    '__module__': 'tests.test_prettier',\n"
         "    '__dict__': <attribute '__dict__' of 'C' objects>,\n"
-        "    '__weakref__': <attribute '__weakref__' of 'C' objects>,"
-        "    '__doc__': None,"
-        "})>"
+        "    '__weakref__': <attribute '__weakref__' of 'C' objects>,\n"
+        "    '__doc__': None,\n"
+        "})>")
 
 
 def test_print(capsys):

--- a/tests/test_prettier.py
+++ b/tests/test_prettier.py
@@ -36,6 +36,18 @@ def test_dict():
         '}')
 
 
+def test_mappingproxy():
+    v = pformat(C.__dict__)
+    print(v)
+    assert v == (
+        "<mappingproxy({{\n"
+        "    '__module__': 'tests.test_prettier',\n"
+        "    '__dict__': <attribute '__dict__' of 'C' objects>,\n"
+        "    '__weakref__': <attribute '__weakref__' of 'C' objects>,"
+        "    '__doc__': None,"
+        "})>"
+
+
 def test_print(capsys):
     pprint({1: 2, 3: 4})
     stdout, stderr = capsys.readouterr()


### PR DESCRIPTION
This is a simple modification to format `mappingproxy` objects (e.g. `__dict__`) as dictionaries.  

I was also thinking about formatting  any `collections.abc.Mapping` object as a dictionary.  If you think that's a good idea, let me know and I'll update the PR.  I wasn't sure if that would be problematic in any edge cases (e.g. generator-like mappings that can only be iterated through once, although I'm not sure if that exists), so for now I'm just handling the specific non-dict mapping class that I run into the most.

I can't get the tests to pass on my machine, but I don't think the issue is related to this PR, and I want to see if they pass on CI.