### PR TITLE
Use executing and asttokens

### DIFF
--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -104,20 +104,18 @@ class Debug:
     output_class = DebugOutput
 
     def __init__(
-        self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None, frame_context_length: int = 50
+        self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None
     ):
         self._show_warnings = env_bool(warnings, 'PY_DEVTOOLS_WARNINGS', True)
         self._highlight = highlight
-        # 50 lines should be enough to make sure we always get the entire function definition
-        self._frame_context_length = frame_context_length
 
     def __call__(self, *args, file_=None, flush_=True, **kwargs) -> None:
-        d_out = self._process(args, kwargs, 'debug')
+        d_out = self._process(args, kwargs)
         s = d_out.str(use_highlight(self._highlight, file_))
         print(s, file=file_, flush=flush_)
 
     def format(self, *args, **kwargs) -> DebugOutput:
-        return self._process(args, kwargs, 'format')
+        return self._process(args, kwargs)
 
     def breakpoint(self):
         import pdb
@@ -127,7 +125,7 @@ class Debug:
     def timer(self, name=None, *, verbose=True, file=None, dp=3) -> Timer:
         return Timer(name=name, verbose=verbose, file=file, dp=dp)
 
-    def _process(self, args, kwargs, func_name: str) -> DebugOutput:
+    def _process(self, args, kwargs) -> DebugOutput:
         """
         BEWARE: this must be called from a function exactly 2 levels below the top of the stack.
         """

--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -4,14 +4,13 @@ import sys
 from .ansi import sformat
 from .prettier import PrettyFormat
 from .timer import Timer
-from .utils import env_bool, env_true, use_highlight
+from .utils import env_bool, env_true, is_literal, use_highlight
 
 __all__ = 'Debug', 'debug'
 MYPY = False
 if MYPY:
-    import ast
     from types import FrameType
-    from typing import Generator, List, Optional, Tuple
+    from typing import Generator, List, Optional
 
 
 pformat = PrettyFormat(
@@ -20,10 +19,6 @@ pformat = PrettyFormat(
     width=int(os.getenv('PY_DEVTOOLS_WIDTH', 120)),
     yield_from_generators=env_true('PY_DEVTOOLS_YIELD_FROM_GEN', True),
 )
-
-
-class IntrospectionError(ValueError):
-    pass
 
 
 class DebugArgument:
@@ -43,7 +38,7 @@ class DebugArgument:
 
     def str(self, highlight=False) -> str:
         s = ''
-        if self.name:
+        if self.name and not is_literal(self.name):
             s = sformat(self.name, sformat.blue, apply=highlight) + ': '
 
         suffix = sformat(
@@ -165,23 +160,20 @@ class Debug:
         lineno = call_frame.f_lineno
         warning = None
 
-        import inspect
+        import executing
 
-        try:
-            file_lines, _ = inspect.findsource(call_frame)
-        except OSError:
+        source = executing.Source.for_frame(call_frame)
+        if not source.text:
             warning = 'no code context for debug call, code inspection impossible'
             arguments = list(self._args_inspection_failed(args, kwargs))
         else:
-            try:
-                first_line, last_line = self._statement_range(call_frame, func_name)
-                func_ast, code_lines = self._parse_code(filename, file_lines, first_line, last_line)
-            except IntrospectionError as e:
-                # parsing failed
-                warning = e.args[0]
+            ex = source.executing(call_frame)
+            # function = ex.code_qualname()
+            if not ex.node:
+                warning = "executing failed to find the calling node"
                 arguments = list(self._args_inspection_failed(args, kwargs))
             else:
-                arguments = list(self._process_args(func_ast, code_lines, args, kwargs))
+                arguments = list(self._process_args(ex, args, kwargs))
 
         return self.output_class(
             filename=filename,
@@ -197,51 +189,14 @@ class Debug:
         for name, value in kwargs.items():
             yield self.output_class.arg_class(value, name=name)
 
-    def _process_args(self, func_ast, code_lines, args, kwargs) -> 'Generator[DebugArgument, None, None]':  # noqa: C901
+    def _process_args(self, ex, args, kwargs) -> 'Generator[DebugArgument, None, None]':  # noqa: C901
         import ast
 
-        complex_nodes = (
-            ast.Call,
-            ast.Attribute,
-            ast.Subscript,
-            ast.IfExp,
-            ast.BoolOp,
-            ast.BinOp,
-            ast.Compare,
-            ast.DictComp,
-            ast.ListComp,
-            ast.SetComp,
-            ast.GeneratorExp,
-        )
-
-        arg_offsets = list(self._get_offsets(func_ast))
-        for i, arg in enumerate(args):
-            try:
-                ast_node = func_ast.args[i]
-            except IndexError:  # pragma: no cover
-                # happens when code has been commented out and there are fewer func_ast args than real args
-                yield self.output_class.arg_class(arg)
-                continue
-
-            if isinstance(ast_node, ast.Name):
-                yield self.output_class.arg_class(arg, name=ast_node.id)
-            elif isinstance(ast_node, complex_nodes):
-                # TODO replace this hack with astor when it get's round to a new release
-                start_line, start_col = arg_offsets[i]
-
-                if i + 1 < len(arg_offsets):
-                    end_line, end_col = arg_offsets[i + 1]
-                else:
-                    end_line, end_col = len(code_lines) - 1, None
-
-                name_lines = []
-                for l_ in range(start_line, end_line + 1):
-                    start_ = start_col if l_ == start_line else 0
-                    end_ = end_col if l_ == end_line else None
-                    name_lines.append(code_lines[l_][start_:end_].strip(' '))
-                yield self.output_class.arg_class(arg, name=' '.join(name_lines).strip(' ,'))
-            else:
-                yield self.output_class.arg_class(arg)
+        func_ast = ex.node
+        atok = ex.source.asttokens()
+        for arg, ast_arg in zip(args, func_ast.args):
+            name = ' '.join(map(str.strip, atok.get_text(ast_arg).splitlines()))
+            yield self.output_class.arg_class(arg, name=name)
 
         kw_arg_names = {}
         for kw in func_ast.keywords:
@@ -249,122 +204,6 @@ class Debug:
                 kw_arg_names[kw.arg] = kw.value.id
         for name, value in kwargs.items():
             yield self.output_class.arg_class(value, name=name, variable=kw_arg_names.get(name))
-
-    def _parse_code(
-        self, filename: str, file_lines: 'List[str]', first_line: int, last_line: int
-    ) -> 'Tuple[ast.AST, List[str]]':
-        """
-        All we're trying to do here is build an AST of the function call statement. However numerous ugly interfaces,
-        lack on introspection support and changes between python versions make this extremely hard.
-        """
-        import ast
-        from textwrap import dedent
-
-        def get_code(_last_line: int) -> str:
-            lines = file_lines[first_line - 1 : _last_line]
-            return dedent(''.join(ln for ln in lines if ln.strip('\n ') and not ln.lstrip(' ').startswith('#')))
-
-        code = get_code(last_line)
-        func_ast = None
-        try:
-            func_ast = self._wrap_parse(code, filename)
-        except (SyntaxError, AttributeError) as e1:
-            # if the trailing bracket(s) of the function is/are on a new line e.g.:
-            # debug(
-            #     foo, bar,
-            # )
-            # inspect ignores it when setting index and we have to add it back
-            for extra in range(1, 6):
-                code = get_code(last_line + extra)
-                try:
-                    func_ast = self._wrap_parse(code, filename)
-                except (SyntaxError, AttributeError):
-                    pass
-                else:
-                    break
-
-            if not func_ast:
-                raise IntrospectionError('error parsing code, {0.__class__.__name__}: {0}'.format(e1))
-
-        if not isinstance(func_ast, ast.Call):
-            raise IntrospectionError('error parsing code, found {0.__class__} not Call'.format(func_ast))
-
-        code_lines = [line for line in code.split('\n') if line]
-        # this removes the trailing bracket from the lines of code meaning it doesn't appear in the
-        # representation of the last argument
-        code_lines[-1] = code_lines[-1][:-1]
-        return func_ast, code_lines
-
-    @staticmethod  # noqa: C901
-    def _statement_range(call_frame: 'FrameType', func_name: str) -> 'Tuple[int, int]':  # noqa: C901
-        """
-        Try to find the start and end of a frame statement.
-        """
-        import dis
-
-        # dis.disassemble(call_frame.f_code, call_frame.f_lasti)
-        # pprint([i for i in dis.get_instructions(call_frame.f_code)])
-
-        instructions = iter(dis.get_instructions(call_frame.f_code))
-        first_line = None
-        last_line = None
-
-        for instr in instructions:  # pragma: no branch
-            if (
-                instr.starts_line
-                and instr.opname in {'LOAD_GLOBAL', 'LOAD_NAME'}
-                and (instr.argval == func_name or (instr.argval == 'debug' and next(instructions).argval == func_name))
-            ):
-                first_line = instr.starts_line
-            if instr.offset == call_frame.f_lasti:
-                break
-
-        if first_line is None:
-            raise IntrospectionError('error parsing code, unable to find "{}" function statement'.format(func_name))
-
-        for instr in instructions:
-            if instr.starts_line:
-                last_line = instr.starts_line - 1
-                break
-
-        if last_line is None:
-            if sys.version_info >= (3, 8):
-                # absolutely no reliable way of getting the last line of the statement, complete hack is to
-                # get the last line of the last statement of the whole code block and go from there
-                # this assumes (perhaps wrongly?) that the reason we couldn't find last_line is that the statement
-                # in question was the last of the block
-                last_line = max(i.starts_line for i in dis.get_instructions(call_frame.f_code) if i.starts_line)
-            else:
-                # in older version of python f_lineno is the end of the statement, not the beginning
-                # so this is a reasonable guess
-                last_line = call_frame.f_lineno
-
-        return first_line, last_line
-
-    @staticmethod
-    def _wrap_parse(code: str, filename: str) -> 'ast.Call':
-        """
-        async wrapper is required to avoid await calls raising a SyntaxError
-        """
-        import ast
-        from textwrap import indent
-
-        code = 'async def wrapper():\n' + indent(code, ' ')
-        return ast.parse(code, filename=filename).body[0].body[0].value
-
-    @staticmethod
-    def _get_offsets(func_ast):
-        import ast
-
-        for arg in func_ast.args:
-            start_line, start_col = arg.lineno - 2, arg.col_offset - 1
-
-            # horrible hack for http://bugs.python.org/issue31241
-            if isinstance(arg, (ast.ListComp, ast.GeneratorExp)):
-                start_col -= 1
-            yield start_line, start_col
-        for kw in func_ast.keywords:
-            yield kw.value.lineno - 2, kw.value.col_offset - 2 - (len(kw.arg) if kw.arg else 0)
 
 
 debug = Debug()

--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -103,9 +103,7 @@ class DebugOutput:
 class Debug:
     output_class = DebugOutput
 
-    def __init__(
-        self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None
-    ):
+    def __init__(self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None):
         self._show_warnings = env_bool(warnings, 'PY_DEVTOOLS_WARNINGS', True)
         self._highlight = highlight
 

--- a/devtools/utils.py
+++ b/devtools/utils.py
@@ -102,6 +102,7 @@ def is_literal(s):
 
     try:
         ast.literal_eval(s)
-        return True
-    except Exception:
+    except ValueError:
         return False
+    else:
+        return True

--- a/devtools/utils.py
+++ b/devtools/utils.py
@@ -95,3 +95,13 @@ def use_highlight(highlight: 'Optional[bool]' = None, file_=None) -> bool:
     if sys.platform == 'win32':  # pragma: no cover
         return isatty(file_) and activate_win_color()
     return isatty(file_)
+
+
+def is_literal(s):
+    import ast
+
+    try:
+        ast.literal_eval(s)
+        return True
+    except Exception:
+        return False

--- a/devtools/utils.py
+++ b/devtools/utils.py
@@ -102,7 +102,7 @@ def is_literal(s):
 
     try:
         ast.literal_eval(s)
-    except ValueError:
+    except (TypeError, MemoryError, SyntaxError, ValueError):
         return False
     else:
         return True

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     url='https://github.com/samuelcolvin/python-devtools',
     license='MIT',
     packages=['devtools'],
+    install_requires=['executing', 'asttokens'],
     python_requires='>=3.6',
     extras_require={
         'pygments': ['Pygments>=2.2.0'],

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,11 @@ setup(
     url='https://github.com/samuelcolvin/python-devtools',
     license='MIT',
     packages=['devtools'],
-    install_requires=['executing', 'asttokens'],
     python_requires='>=3.6',
+    install_requires=[
+        'executing>=0.8.0,<1.0.0',
+        'asttokens>=2.0.0,<3.0.0',
+    ],
     extras_require={
         'pygments': ['Pygments>=2.2.0'],
     },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,5 @@
-asttokens==2.0.4
 black==19.10b0
 coverage==5.2.1
-executing==0.5.4
 flake8==3.8.3
 isort==5.2.1
 pycodestyle==2.6.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,7 @@
+asttokens==2.0.4
 black==19.10b0
 coverage==5.2.1
+executing==0.5.4
 flake8==3.8.3
 isort==5.2.1
 pycodestyle==2.6.0

--- a/tests/test_expr_render.py
+++ b/tests/test_expr_render.py
@@ -52,7 +52,14 @@ def test_exotic_types():
     s = re.sub(r':\d{2,}', ':<line no>', str(v))
     s = re.sub(r'(at 0x)\w+', r'\1<hash>', s)
     print('\n---\n{}\n---'.format(v))
-    # list and generator comprehensions are wrong because ast is wrong, see https://bugs.python.org/issue31241
+
+    # Generator expression source changed in 3.8 to include parentheses, see:
+    # https://github.com/gristlabs/asttokens/pull/50
+    # https://bugs.python.org/issue31241
+    genexpr_source = "a for a in aa"
+    if sys.version_info[:2] > (3, 7):
+        genexpr_source = f"({genexpr_source})"
+
     assert (
         "tests/test_expr_render.py:<line no> test_exotic_types\n"
         "    sum(aa): 6 (int)\n"
@@ -68,7 +75,7 @@ def test_exotic_types():
         "        2: 3,\n"
         "        3: 4,\n"
         "    } (dict) len=3\n"
-        "    (a for a in aa): (\n"
+        f"    {genexpr_source}: (\n"
         "        1,\n"
         "        2,\n"
         "        3,\n"

--- a/tests/test_expr_render.py
+++ b/tests/test_expr_render.py
@@ -307,3 +307,19 @@ def test_executing_failure():
         '(executing failed to find the calling node)\n'
         '    [1, 2] (list) len=2'
     )
+
+
+def test_format_inside_error():
+    debug.timer()
+    x = 1
+    y = 2
+    try:
+        raise RuntimeError(debug.format([x, y]))
+    except RuntimeError as e:
+        v = str(e)
+
+    s = re.sub(r':\d{2,}', ':<line no>', str(v))
+    assert s == (
+        'tests/test_expr_render.py:<line no> test_format_inside_error\n'
+        '    [x, y]: [1, 2] (list) len=2'
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,7 +77,6 @@ def test_odd_path(mocker):
     assert re.search(r"/.*?/test_main.py:\d{2,} test_odd_path\n    'test' \(str\) len=4", str(v)), v
 
 
-@pytest.mark.xfail(sys.platform == 'win32', reason='yet unknown windows problem')
 def test_small_call_frame():
     debug_ = Debug(warnings=False, frame_context_length=2)
     v = debug_.format(
@@ -103,8 +102,7 @@ def test_small_call_frame_warning():
     )
     print('\n---\n{}\n---'.format(v))
     assert re.sub(r':\d{2,}', ':<line no>', str(v)) == (
-        'tests/test_main.py:<line no> test_small_call_frame_warning '
-        '(error parsing code, unable to find "format" function statement)\n'
+        'tests/test_main.py:<line no> test_small_call_frame_warning\n'
         '    1 (int)\n'
         '    2 (int)\n'
         '    3 (int)'
@@ -272,26 +270,12 @@ def test_pretty_error():
     )
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 8), reason='different between 3.7 and 3.8')
-def test_multiple_debugs_37():
+def test_multiple_debugs():
     debug.format([i * 2 for i in range(2)])
     debug.format([i * 2 for i in range(2)])
     v = debug.format([i * 2 for i in range(2)])
     s = re.sub(r':\d{2,}', ':<line no>', str(v))
     assert s == (
-        'tests/test_main.py:<line no> test_multiple_debugs_37\n'
+        'tests/test_main.py:<line no> test_multiple_debugs\n'
         '    [i * 2 for i in range(2)]: [0, 2] (list) len=2'
-    )
-
-
-@pytest.mark.skipif(sys.version_info < (3, 8), reason='different between 3.7 and 3.8')
-def test_multiple_debugs_38():
-    debug.format([i * 2 for i in range(2)])
-    debug.format([i * 2 for i in range(2)])
-    v = debug.format([i * 2 for i in range(2)])
-    s = re.sub(r':\d{2,}', ':<line no>', str(v))
-    # FIXME there's an extraneous bracket here, due to some error building code from the ast
-    assert s == (
-        'tests/test_main.py:<line no> test_multiple_debugs_38\n'
-        '    ([i * 2 for i in range(2)]: [0, 2] (list) len=2'
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,7 +78,7 @@ def test_odd_path(mocker):
 
 
 def test_small_call_frame():
-    debug_ = Debug(warnings=False, frame_context_length=2)
+    debug_ = Debug(warnings=False)
     v = debug_.format(
         1,
         2,
@@ -94,7 +94,7 @@ def test_small_call_frame():
 
 @pytest.mark.xfail(sys.platform == 'win32', reason='yet unknown windows problem')
 def test_small_call_frame_warning():
-    debug_ = Debug(frame_context_length=2)
+    debug_ = Debug()
     v = debug_.format(
         1,
         2,

--- a/tests/test_prettier.py
+++ b/tests/test_prettier.py
@@ -39,7 +39,7 @@ def test_dict():
 def test_print(capsys):
     pprint({1: 2, 3: 4})
     stdout, stderr = capsys.readouterr()
-    assert stdout == (
+    assert strip_ansi(stdout) == (
         '{\n'
         '    1: 2,\n'
         '    3: 4,\n'


### PR DESCRIPTION
This brings in two dependencies to do the heavy lifting for debug:

- https://github.com/alexmojaki/executing finds the AST node
- https://github.com/gristlabs/asttokens converts AST nodes to source code

Both are very well tested and reliable and are used in several other libraries with no issues, including https://github.com/gruns/icecream. You'll note that several test cases no longer give warnings. In particular this fixes #47 and #71.

`executing` can identify the AST node in almost all situations, which means:

- #69 will be easy to implement, not just in variable assignments but also in things like list comprehensions as a commenter mentions.
- Any function name is allowed, e.g. `from devtools import debug as dbg` will work. In fact the function can be any expression.
