### PR TITLE
Use secure builtins standard module, instead of the __builtins__

### DIFF
--- a/devtools/__main__.py
+++ b/devtools/__main__.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import sys
 from pathlib import Path
@@ -7,12 +8,13 @@ from .version import VERSION
 # language=python
 install_code = """
 # add devtools `debug` function to builtins
+import builtins
 try:
     from devtools import debug
 except ImportError:
     pass
 else:
-    __builtins__['debug'] = debug
+    setattr(builtins, "debug", debug)
 """
 
 
@@ -24,7 +26,7 @@ def print_code() -> int:
 def install() -> int:
     print('[WARNING: this command is experimental, report issues at github.com/samuelcolvin/python-devtools]\n')
 
-    if 'debug' in __builtins__.__dict__:
+    if 'debug' in builtins.dir():
         print('Looks like devtools is already installed.')
         return 0
 

--- a/devtools/__main__.py
+++ b/devtools/__main__.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     pass
 else:
-    setattr(builtins, "debug", debug)
+    setattr(builtins, 'debug', debug)
 """
 
 

--- a/devtools/__main__.py
+++ b/devtools/__main__.py
@@ -26,7 +26,7 @@ def print_code() -> int:
 def install() -> int:
     print('[WARNING: this command is experimental, report issues at github.com/samuelcolvin/python-devtools]\n')
 
-    if 'debug' in builtins.dir():
+    if hasattr(builtins, 'debug'):
         print('Looks like devtools is already installed.')
         return 0
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,7 +120,7 @@ try:
 except ImportError:
     pass
 else:
-    setattr(builtins, "debug", debug)
+    setattr(builtins, 'debug', debug)
 ```
 
 The `ImportError` exception is important since you'll want python to run fine even if *devtools* isn't installed.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,12 +114,13 @@ which is always imported.
 
 ```py
 # add devtools `debug` function to builtins
+import builtins
 try:
     from devtools import debug
 except ImportError:
     pass
 else:
-    __builtins__['debug'] = debug
+    setattr(builtins, "debug", debug)
 ```
 
 The `ImportError` exception is important since you'll want python to run fine even if *devtools* isn't installed.


### PR DESCRIPTION
Due to documentation, it seems that using `__builtins__` directly is not reliable. Instead they were using the ``__builtin__`` module which was renamed to ``builtins``. 

> Having `__builtins__` and `__builtin__` both is clearly a bad idea. 

[[Python-Dev] `__builtin__` vs `__builtins__`](https://mail.python.org/pipermail/python-dev/2005-December/058652.html)

I hope this helps, as I am just starting with open source contributions.
