### PR TITLE
more precise timer summary

### DIFF
--- a/devtools/timer.py
+++ b/devtools/timer.py
@@ -4,7 +4,7 @@ __all__ = ('Timer',)
 
 MYPY = False
 if MYPY:
-    from typing import Any, List, Optional, Set
+    from typing import Any, List, Optional
 
 # required for type hinting because I (stupidly) added methods called `str`
 StrType = str

--- a/devtools/timer.py
+++ b/devtools/timer.py
@@ -66,7 +66,7 @@ class Timer:
             print(r.str(self.dp), file=self.file, flush=True)
         return r
 
-    def summary(self, verbose: bool = False) -> 'Set[float]':
+    def summary(self, verbose: bool = False) -> 'List[float]':
         times = []
         for r in self.results:
             if not r.finish:

--- a/devtools/timer.py
+++ b/devtools/timer.py
@@ -1,4 +1,4 @@
-from time import time
+from time import perf_counter
 
 __all__ = ('Timer',)
 
@@ -15,10 +15,10 @@ class TimerResult:
         self._name = name
         self.verbose = verbose
         self.finish: 'Optional[float]' = None
-        self.start = time()
+        self.start = perf_counter()
 
     def capture(self) -> None:
-        self.finish = time()
+        self.finish = perf_counter()
 
     def elapsed(self) -> float:
         if self.finish:
@@ -67,13 +67,13 @@ class Timer:
         return r
 
     def summary(self, verbose: bool = False) -> 'Set[float]':
-        times = set()
+        times = []
         for r in self.results:
             if not r.finish:
                 r.capture()
             if verbose:
                 print(f'    {r.str(self.dp)}', file=self.file)
-            times.add(r.elapsed())
+            times.append(r.elapsed())
 
         if times:
             from statistics import mean, stdev


### PR DESCRIPTION
- use `time.perf_counter` as the most precise way of measuring performance
- don't lose fast timer samples when calculating summary, use a list instead of a set