### PR TITLE
Allow executing dependency to be >1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 requires-python = '>=3.7'
 dependencies = [
-    'executing>=0.9.1,<2.0.0',
+    'executing>=1.1.1,<2.0.0',
     'asttokens>=2.0.0,<3.0.0',
 ]
 optional-dependencies = {pygments = ['Pygments>=2.2.0'] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 requires-python = '>=3.7'
 dependencies = [
-    'executing>=1.1.1,<2.0.0',
+    'executing>=1.1.1',
     'asttokens>=2.0.0,<3.0.0',
 ]
 optional-dependencies = {pygments = ['Pygments>=2.2.0'] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 requires-python = '>=3.7'
 dependencies = [
-    'executing>=0.9.1,<1.0.0',
+    'executing>=0.9.1,<2.0.0',
     'asttokens>=2.0.0,<3.0.0',
 ]
 optional-dependencies = {pygments = ['Pygments>=2.2.0'] }


### PR DESCRIPTION
Closes #114 

I just tested it with `executing==1.2.0` and `asttokens==2.1.0` and everything seems to work, the tests pass.

This will allow users to update `executing` to a version greater than `1.0.0`, for example in the case of global installation.

Please let me know if there is anything that would prevent this change from being possible. I checked the `executing`'s API and there wasn't any breaking change.