### PR TITLE
Add option to change print function

### DIFF
--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -108,7 +108,7 @@ class DebugOutput:
 class Debug:
     output_class = DebugOutput
 
-    def __init__(self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None, logger_function: 'Callable[[str], None]' = None):
+    def __init__(self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None, logger_function: 'Optional[Callable[[str], None]]' = None):
         self._show_warnings = env_bool(warnings, 'PY_DEVTOOLS_WARNINGS', True)
         self._highlight = highlight
         self._logger_function = logger_function

--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -10,7 +10,7 @@ __all__ = 'Debug', 'debug'
 MYPY = False
 if MYPY:
     from types import FrameType
-    from typing import Any, Generator, List, Optional, Union, Callable
+    from typing import Any, Callable, Generator, List, Optional, Union
 
 pformat = PrettyFormat(
     indent_step=int(os.getenv('PY_DEVTOOLS_INDENT', 4)),
@@ -108,7 +108,13 @@ class DebugOutput:
 class Debug:
     output_class = DebugOutput
 
-    def __init__(self, *, warnings: 'Optional[bool]' = None, highlight: 'Optional[bool]' = None, logger_function: 'Optional[Callable[[str], None]]' = None):
+    def __init__(
+            self,
+            *,
+            warnings: 'Optional[bool]' = None,
+            highlight: 'Optional[bool]' = None,
+            logger_function: 'Optional[Callable[[str], None]]' = None,
+    ):
         self._show_warnings = env_bool(warnings, 'PY_DEVTOOLS_WARNINGS', True)
         self._highlight = highlight
         self._logger_function = logger_function


### PR DESCRIPTION
I added logger_function parameter to Debug() class that replaces print if set. Here is an example of usage with loguru:

```python
from devtools import Debug
from loguru import logger

debug = Debug(logger_function=logger.debug)

test_object = {
    "string": "test",
    "integer": 123,
    "nested": {
        "key": "value"
    }
}
debug(test_object)
# 2023-10-29 18:38:45.211 | DEBUG    | devtools.debug:__call__:127 - logger_func_test.py:13 <module>
#     test_object: {
#         'string': 'test',
#         'integer': 123,
#         'nested': {
#             'key': 'value',
#         },
#     } (dict) len=3

```