### PR TITLE
✨ Add support for sorting data in `insert_assert` based on previous data (e.g. from a previous run) to minimize the diff

### DIFF
--- a/devtools/pytest_plugin.py
+++ b/devtools/pytest_plugin.py
@@ -39,24 +39,24 @@ insert_assert_summary: ContextVar[list[str]] = ContextVar('insert_assert_summary
 
 def sort_data_from_source(source: Any, value: Any) -> Any:
     if isinstance(value, dict) and isinstance(source, dict):
-        new_value = {}
+        new_dict = {}
         used_keys = set()
         for k, v in source.items():
             if k in value:
-                new_value[k] = sort_data_from_source(v, value[k])
+                new_dict[k] = sort_data_from_source(v, value[k])
             used_keys.add(k)
         for k, v in value.items():
             if k not in used_keys:
-                new_value[k] = v
-        return new_value
+                new_dict[k] = v
+        return new_dict
     elif isinstance(value, list) and isinstance(source, list):
-        new_value = []
+        new_list: list[Any] = []
         for i, v in enumerate(value):
             if i < len(source):
-                new_value.append(sort_data_from_source(source[i], v))
+                new_list.append(sort_data_from_source(source[i], v))
             else:
-                new_value.append(v)
-        return new_value
+                new_list.append(v)
+        return new_list
     else:
         return value
 

--- a/devtools/pytest_plugin.py
+++ b/devtools/pytest_plugin.py
@@ -37,15 +37,41 @@ insert_assert_calls: ContextVar[int] = ContextVar('insert_assert_calls', default
 insert_assert_summary: ContextVar[list[str]] = ContextVar('insert_assert_summary')
 
 
-def insert_assert(value: Any) -> int:
+def sort_data_from_source(source: Any, value: Any) -> Any:
+    if isinstance(value, dict) and isinstance(source, dict):
+        new_value = {}
+        used_keys = set()
+        for k, v in source.items():
+            if k in value:
+                new_value[k] = sort_data_from_source(v, value[k])
+            used_keys.add(k)
+        for k, v in value.items():
+            if k not in used_keys:
+                new_value[k] = v
+        return new_value
+    elif isinstance(value, list) and isinstance(source, list):
+        new_value = []
+        for i, v in enumerate(value):
+            if i < len(source):
+                new_value.append(sort_data_from_source(source[i], v))
+            else:
+                new_value.append(v)
+        return new_value
+    else:
+        return value
+
+
+def insert_assert(value: Any, prev: Any = None) -> int:
     call_frame: FrameType = sys._getframe(1)
     if sys.version_info < (3, 8):  # pragma: no cover
         raise RuntimeError('insert_assert() requires Python 3.8+')
-
+    if prev:
+        use_value = sort_data_from_source(prev, value)
+    else: use_value = value
     format_code = load_black()
     ex = Source.for_frame(call_frame).executing(call_frame)
     if ex.node is None:  # pragma: no cover
-        python_code = format_code(str(custom_repr(value)))
+        python_code = format_code(str(custom_repr(use_value)))
         raise RuntimeError(
             f'insert_assert() was unable to find the frame from which it was called, called with:\n{python_code}'
         )
@@ -55,7 +81,7 @@ def insert_assert(value: Any) -> int:
     else:
         arg = ' '.join(map(str.strip, ex.source.asttokens().get_text(ast_arg).splitlines()))
 
-    python_code = format_code(f'# insert_assert({arg})\nassert {arg} == {custom_repr(value)}')
+    python_code = format_code(f'# insert_assert({arg})\nassert {arg} == {custom_repr(use_value)}')
 
     python_code = textwrap.indent(python_code, ex.node.col_offset * ' ')
     to_replace.append(ToReplace(Path(call_frame.f_code.co_filename), ex.node.lineno, ex.node.end_lineno, python_code))

--- a/devtools/pytest_plugin.py
+++ b/devtools/pytest_plugin.py
@@ -67,7 +67,8 @@ def insert_assert(value: Any, prev: Any = None) -> int:
         raise RuntimeError('insert_assert() requires Python 3.8+')
     if prev:
         use_value = sort_data_from_source(prev, value)
-    else: use_value = value
+    else:
+        use_value = value
     format_code = load_black()
     ex = Source.for_frame(call_frame).executing(call_frame)
     if ex.node is None:  # pragma: no cover

--- a/tests/test_insert_assert.py
+++ b/tests/test_insert_assert.py
@@ -230,17 +230,13 @@ def test_dict(insert_assert):
     }
     # insert_assert(new_data)
     assert new_data == {
-        "foo": 1,
-        "bar": [
-            {
-                "name": "Pydantic",
-                "tags": ["validation", "json"],
-                "description": "Data validation library",
-            },
-            {"name": "FastAPI", "description": "Web API framework in Python"},
-            {"name": "SQLModel", "description": "DBs and Python"},
-            {"name": "ARQ"},
+        'foo': 1,
+        'bar': [
+            {'name': 'Pydantic', 'tags': ['validation', 'json'], 'description': 'Data validation library'},
+            {'name': 'FastAPI', 'description': 'Web API framework in Python'},
+            {'name': 'SQLModel', 'description': 'DBs and Python'},
+            {'name': 'ARQ'},
         ],
-        "baz": 6,
+        'baz': 6,
     }"""
     )

--- a/tests/test_insert_assert.py
+++ b/tests/test_insert_assert.py
@@ -222,16 +222,16 @@ def test_dict(insert_assert):
                 "tags": ["validation", "json"],
                 "name": "Pydantic",
             },
-            {"name": "FastAPI", "description": "Web API framework in Python"},
+            {"description": "Web API framework in Python", "name": "FastAPI"},
             {"description": "DBs and Python", "name": "SQLModel"},
             {"name": "ARQ"},
         ],
         "baz": 6,
-        "foo": 12,
+        "foo": 1,
     }
     # insert_assert(new_data)
     assert new_data == {
-        "foo": 12,
+        "foo": 1,
         "bar": [
             {
                 "name": "Pydantic",

--- a/tests/test_insert_assert.py
+++ b/tests/test_insert_assert.py
@@ -191,12 +191,12 @@ def test_dict(insert_assert):
                 "tags": ["validation", "json"],
                 "name": "Pydantic",
             },
-            {"name": "FastAPI", "description": "Web API framework in Python"},
+            {"description": "Web API framework in Python", "name": "FastAPI"},
             {"description": "DBs and Python", "name": "SQLModel"},
             {"name": "ARQ"},
         ],
         "baz": 6,
-        "foo": 12,
+        "foo": 1,
     }
     insert_assert(new_data, old_data)
 """

--- a/tests/test_insert_assert.py
+++ b/tests/test_insert_assert.py
@@ -204,8 +204,7 @@ def test_dict(insert_assert):
     result = pytester_pretty.runpytest()
     result.assert_outcomes(passed=1)
     assert test_file.read_text() == (
-        """
-def test_dict(insert_assert):
+        """def test_dict(insert_assert):
     old_data = {
         "foo": 1,
         "bar": [
@@ -243,6 +242,5 @@ def test_dict(insert_assert):
             {"name": "ARQ"},
         ],
         "baz": 6,
-    }
-"""
+    }"""
     )


### PR DESCRIPTION
✨ Add support for sorting data in `insert_assert` based on previous data (e.g. from a previous run) to minimize the diff.

## Motivation

Of of the main use cases for me, and where `insert_assert` shines the most (for me) is updating the assert for a big OpenAPI output from FastAPI (in FastAPI tests and SQLModel tests).

Nevertheless, as the previous tests used Pydantic 1.x, the output generated by Pydantic v2 has some slight changes.

But, Pydantic v2 outputs some keys in JSON Schema in different order than v1... which is fine, because dicts are not ordered, equality is the same, tests would still pass, etc. ...but the resulting diff from the previous data and the new inserted data is quite big, just for these differences (e.g. `title` now comes before the rest). And that makes it more difficult to see the actual changes (e.g. values with `str | None` now have a schema of "any between string and null").

For the FastAPI tests, during the migration to Pydantic v2, I manually updated all those differences one by one to check the actual content change.

Now I'm updating SQLModel and having a local version of this helps a lot, the git diff shows only what actually changed, and I can verify and update anything necessary much more quickly.

## Problem Example

Imagine you have a test that looks like:

```Python
def test_dict(insert_assert):
    data = get_data()
    # insert_assert(data)
    assert data == {
        "foo": 1,
        "bar": [
            {"name": "Pydantic", "tags": ["validation", "json"]},
            {"name": "FastAPI", "description": "Web API framework in Python"},
            {"name": "SQLModel"},
        ],
        "baz": 3,
    }
```

But now `get_data()` was updated and returns:

```
{
    "bar": [
        {
            "description": "Data validation library",
            "tags": ["validation", "json"],
            "name": "Pydantic",
        },
        {"name": "FastAPI", "description": "Web API framework in Python"},
        {"description": "DBs and Python", "name": "SQLModel"},
        {"name": "ARQ"},
    ],
    "baz": 6,
    "foo": 12,
}
```

If you just run `insert_assert` as before:

```Python
def test_dict(insert_assert):
    data = get_data()
    insert_assert(data)
```

You would normally get this:

```Python
def test_dict(insert_assert):
    data = get_data()
    # insert_assert(data)
    assert data == {
        "bar": [
            {
                "description": "Data validation library",
                "tags": ["validation", "json"],
                "name": "Pydantic",
            },
            {"name": "FastAPI", "description": "Web API framework in Python"},
            {"description": "DBs and Python", "name": "SQLModel"},
            {"name": "ARQ"},
        ],
        "baz": 6,
        "foo": 12,
    }
```

This has a larger diff, although the differences are not that big:

```diff
def test_dict(insert_assert):
    data = get_data()
    # insert_assert(data)
    assert data == {
-        "foo": 1,
        "bar": [
-            {"name": "Pydantic", "tags": ["validation", "json"]},
+            {"description": "Data validation library", "tags": ["validation", "json"], "name": "Pydantic"},
-            {"name": "FastAPI", "description": "Web API framework in Python"},
+           {"description": "Web API framework in Python", "name": "FastAPI"},
-            {"name": "SQLModel"},
+           {"description": "DBs and Python", "name": "SQLModel"},
+           {"name": "ARQ"},
        ],
-        "baz": 3,
+       "baz": 6,
+      "foo": 1,
    }
```

## Solution

Now let's start with the same original example:

```Python
def test_dict(insert_assert):
    data = get_data()
    # insert_assert(data)
    assert data == {
        "foo": 1,
        "bar": [
            {"name": "Pydantic", "tags": ["validation", "json"]},
            {"name": "FastAPI", "description": "Web API framework in Python"},
            {"name": "SQLModel"},
        ],
        "baz": 3,
    }
```

When updating it to run `insert_assert` again, you can pass as the second argument the old data:

```Python
def test_dict(insert_assert):
    data = get_data()
    insert_assert(data, {
        "foo": 1,
        "bar": [
            {"name": "Pydantic", "tags": ["validation", "json"]},
            {"name": "FastAPI", "description": "Web API framework in Python"},
            {"name": "SQLModel"},
        ],
        "baz": 3,
    })
```

And now when you run it, it will have the same new data, but with the keys in the new dicts sorted based on the order of the older data, minimizing the git diff:

```diff
def test_dict(insert_assert):
    data = get_data()
    insert_assert(data, {
        "foo": 1,
        "bar": [
-            {"name": "Pydantic", "tags": ["validation", "json"]},
+            {"name": "Pydantic", "tags": ["validation", "json"], "description": "Data validation library"},
            {"name": "FastAPI", "description": "Web API framework in Python"},
-            {"name": "SQLModel"},
+           {"name": "SQLModel", "description": "DBs and Python"},
+           {"name": "ARQ"},
        ],
-       "baz": 3,
+      "baz": 6,
    })
```

Notice, for example, how `"foo"` was kept at the top of the dict, so there's no diff for `"foo"` now (which didn't change).

And the dict for `FastAPI` doesn't have diff changes.