### PR TITLE
🔊 Add info about one reason for `RuntimeError`, which is otherwise difficult to catch

### DIFF
--- a/devtools/pytest_plugin.py
+++ b/devtools/pytest_plugin.py
@@ -47,7 +47,13 @@ def insert_assert(value: Any) -> int:
     if ex.node is None:  # pragma: no cover
         python_code = format_code(str(custom_repr(value)))
         raise RuntimeError(
-            f'insert_assert() was unable to find the frame from which it was called, called with:\n{python_code}'
+            'insert_assert() was unable to find the frame from which it was called.\n\n'
+            "Sometimes this happens when there's an assert statement with a an error "
+            'message with multiple lines, like: '
+            "\n\nassert foo == bar, (\n    'foo should be\n    equal to bar'\n)\n\n"
+            'You can try commenting out that assert statement while you run '
+            'insert_assert() and then uncommenting it afterwards.\n\n'
+            f'insert_assert was called with:\n{python_code}'
         )
     ast_arg = ex.node.args[0]  # type: ignore[attr-defined]
     if isinstance(ast_arg, ast.Name):

--- a/devtools/pytest_plugin.py
+++ b/devtools/pytest_plugin.py
@@ -50,7 +50,7 @@ def insert_assert(value: Any) -> int:
             'insert_assert() was unable to find the frame from which it was called.\n\n'
             "Sometimes this happens when there's an assert statement with a an error "
             'message with multiple lines, like: '
-            "\n\nassert foo == bar, (\n    'foo should be\n    equal to bar'\n)\n\n"
+            "\n\nassert foo == bar, (\n    'foo should be '\n    'equal to bar'\n)\n\n"
             'You can try commenting out that assert statement while you run '
             'insert_assert() and then uncommenting it afterwards.\n\n'
             f'insert_assert was called with:\n{python_code}'


### PR DESCRIPTION
🔊 Add info about one reason for `RuntimeError`, which is otherwise difficult to catch

When there's a multiline error message in an assert, `insert_assert` can't find the frame, probably a quirk of Python. This adds a message showing what might be the problem.

Here's an example test that breaks with the `RuntimeError`:

```Python
def test_multiline_error_message(insert_assert):
    assert True, (
        "This error message has "
        "more than one line."
    )
    insert_assert(1)
```

The new error will show:

```
RuntimeError: insert_assert() was unable to find the frame from which it was called.

Sometimes this happens when there's an assert statement with a an error message with multiple lines, like: 

assert foo == bar, (
    'foo should be '
    'equal to bar'
)

You can try commenting out that assert statement while you run insert_assert() and then uncommenting it afterwards.

insert_assert was called with:
1
```