### PR TITLE
Add support for IPython debugger to breakpoint

### DIFF
--- a/devtools/debug.py
+++ b/devtools/debug.py
@@ -134,9 +134,14 @@ class Debug:
         return self._process(args, kwargs, frame_depth_)
 
     def breakpoint(self) -> None:
-        import pdb
-
-        pdb.Pdb(skip=['devtools.*']).set_trace()
+        """
+        Launch IPython debugger if installed. Otherwise, launch pdb.
+        """
+        try:
+            from IPython.terminal.debugger import TerminalPdb as Pdb
+        except ImportError:
+            from pdb import Pdb
+        Pdb(skip=['devtools.*']).set_trace()
 
     def timer(self, name: 'Optional[str]' = None, *, verbose: bool = True, file: 'Any' = None, dp: int = 3) -> Timer:
         return Timer(name=name, verbose=verbose, file=file, dp=dp)


### PR DESCRIPTION
I think this tool is very handy and concise, beforehand I used to paste `from IPython import embed; embed(colors='neutral')` for debugging purposes.

Python 3.7 introduced the built-in function `breakpoint()` via [PEP 553](https://peps.python.org/pep-0553/). I read the `Debug` implementation and noticed that devtool's `debug.breakpoint()` and built-in `breakpoint()` produce the same output and behaviour.

In order to avoid this redundancy and to enhance the `debug.breakpoint()` method, I got an idea to add support for IPython debugger. This way we have syntax highlighting (closer to `prettier print` output), tab completion, etc., keeping the same interface as `pdb`.