### PR TITLE
Fix macos-latest and 3.7 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
+        include:
+          - os: macos-13
+            python-version: '3.7'
 
     env:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
       EXTRAS: yes
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
`macos-latest` (`macos-14`) was migrated to ARM runner, stopping support for Python 3.7. CI is updated accordingly.

To be considered before https://github.com/samuelcolvin/python-devtools/pull/154

Context: https://github.com/actions/setup-python/issues/856
